### PR TITLE
Add description to 'infrastructure' tag

### DIFF
--- a/src/content/apps/protocol-guild.md
+++ b/src/content/apps/protocol-guild.md
@@ -8,7 +8,7 @@ featured: true
 tags:
   - streaming
   - collective
-  - infrastructure
+  - infrastructure Protocol Guild is a collective of Ethereum core contributors.
 lastUpdated: '2026-02-13'
 relatedMechanisms:
 


### PR DESCRIPTION
Updated the tags section to include a description for 'infrastructure'.